### PR TITLE
PR: Create setup.py script

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,5 +8,6 @@
   "description": "Plugin for Spyder IDE.",
   "version": "0.1.0",
   "create_config_page": "n",
-  "use_ciocheck": "y"
+  "use_ciocheck": "y",
+  "support_python_2": "n"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,5 +9,6 @@
   "version": "0.1.0",
   "create_config_page": "n",
   "use_ciocheck": "y",
-  "support_python_2": "n"
+  "support_python_2": "n",
+  "use_versioneer": "y"
 }

--- a/{{ cookiecutter.repo_name }}/setup.cfg
+++ b/{{ cookiecutter.repo_name }}/setup.cfg
@@ -1,2 +1,16 @@
 [bdist_wheel]
 universal=1
+
+{% if cookiecutter.use_versioneer == 'y' %}
+# See the docstring in versioneer.py for instructions. Note that you must
+# re-run 'versioneer.py setup' after changing this section, and commit the
+# resulting files.
+
+[versioneer]
+VCS = git
+style = pep440
+versionfile_source = {{ cookiecutter.repo_name }}/_version.py
+versionfile_build = {{ cookiecutter.repo_name }}/_version.py
+tag_prefix = v
+
+{% end_if%}

--- a/{{ cookiecutter.repo_name }}/setup.cfg
+++ b/{{ cookiecutter.repo_name }}/setup.cfg
@@ -13,4 +13,4 @@ versionfile_source = {{ cookiecutter.repo_name }}/_version.py
 versionfile_build = {{ cookiecutter.repo_name }}/_version.py
 tag_prefix = v
 
-{% end_if%}
+{% endif%}

--- a/{{ cookiecutter.repo_name }}/setup.py
+++ b/{{ cookiecutter.repo_name }}/setup.py
@@ -6,3 +6,63 @@
 # (see LICENSE.txt for details)
 # -----------------------------------------------------------------------------
 """Setup script for {{ cookiecutter.project_name }}."""
+
+# Standard library imports
+import ast
+import os
+
+# Third party imports
+from setuptools import find_packages, setup
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+
+def get_version(module='{{ cookiecutter.project_name }}'):
+    """Get version."""
+    with open(os.path.join(HERE, module, '__init__.py'), 'r') as f:
+        data = f.read()
+    lines = data.split('\n')
+    for line in lines:
+        if line.startswith('VERSION_INFO'):
+            version_tuple = ast.literal_eval(line.split('=')[-1].strip())
+            version = '.'.join(map(str, version_tuple))
+            break
+    return version
+
+
+def get_description():
+    """Get long description."""
+    with open(os.path.join(HERE, 'README.rst'), 'r') as f:
+        data = f.read()
+    return data
+
+
+REQUIREMENTS = ['spyder']
+
+
+setup(
+    name='{{ cookiecutter.project_name }}',
+    version=get_version(),
+    keywords=[""],
+    url='https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.github_username }}',
+    license='MIT',
+    author='{{ cookiecutter.author }}',
+    author_email='{{ cookiecutter.email }}',
+    description='{{ cookiecutter.description }}',
+    long_description=get_description(),
+    packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
+    install_requires=REQUIREMENTS,
+    classifiers=[
+        'Development Status :: 1 - Planning',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: MacOS',
+        'Operating System :: Microsoft :: Windows',
+        'Operating System :: POSIX :: Linux',
+        {% if cookiecutter.support_python_2 == 'y' %}
+        'Programming Language :: Python :: 2.7',
+        {% endif %}
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6'
+    ])

--- a/{{ cookiecutter.repo_name }}/setup.py
+++ b/{{ cookiecutter.repo_name }}/setup.py
@@ -13,10 +13,13 @@ import os
 
 # Third party imports
 from setuptools import find_packages, setup
+{% if cookiecutter.use_versioneer == 'y' %}
+import versioneer
+{% endif %}
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
-
+{% if cookiecutter.use_versioneer == 'n' %}
 def get_version(module='{{ cookiecutter.project_name }}'):
     """Get version."""
     with open(os.path.join(HERE, module, '__init__.py'), 'r') as f:
@@ -29,6 +32,7 @@ def get_version(module='{{ cookiecutter.project_name }}'):
             break
     return version
 
+{% endif %}
 
 def get_description():
     """Get long description."""
@@ -42,7 +46,12 @@ REQUIREMENTS = ['spyder']
 
 setup(
     name='{{ cookiecutter.project_name }}',
+{% if cookiecutter.use_versioneer == 'y' %}
+    version=versioneer.get_version(),
+    cmdclass=versioneer.get_cmdclass(),
+{% else %}
     version=get_version(),
+{% endif %}
     keywords=[""],
     url='https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.github_username }}',
     license='MIT',

--- a/{{ cookiecutter.repo_name }}/setup.py
+++ b/{{ cookiecutter.repo_name }}/setup.py
@@ -52,7 +52,7 @@ setup(
 {% else %}
     version=get_version(),
 {% endif %}
-    keywords=[""],
+    keywords=['Spyder', 'Plugin'],
     url='https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.github_username }}',
     license='MIT',
     author='{{ cookiecutter.author }}',


### PR DESCRIPTION
Fixes: #5 

----------------
I added an option `support_python_2`, I think It could be useful (i. e. I'll not support python2 in _spyder-reports_ because latest version of Pweave will drop its support)